### PR TITLE
chore(release): bump chart version to 3.5.1012

### DIFF
--- a/infrastructure/rag/Chart.yaml
+++ b/infrastructure/rag/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   form rag. rag is an application, where you can upload your own documents and
   ask question about their content and the rag will answer them.
 type: application
-version: 3.4.0
+version: 3.5.1012
 appVersion: "v3.5.1012"
 dependencies:
 - name: langfuse


### PR DESCRIPTION
Bump Chart.yaml version to 3.5.1012 (appVersion unchanged).